### PR TITLE
feat: add Springdoc OpenAPI integration for automatic API documentation

### DIFF
--- a/hnam-courseware/pom.xml
+++ b/hnam-courseware/pom.xml
@@ -89,6 +89,11 @@
 			<artifactId>modelmapper</artifactId>
 			<version>3.2.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/hnam-courseware/src/main/java/com/hoangnam25/hnam_courseware/config/SecurityConfig.java
+++ b/hnam-courseware/src/main/java/com/hoangnam25/hnam_courseware/config/SecurityConfig.java
@@ -39,6 +39,9 @@ public class SecurityConfig {
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception


### PR DESCRIPTION
Added Springdoc OpenAPI for automatic API documentation and integrated Swagger UI

- Configured Springdoc OpenAPI to generate API docs.
- Added Swagger UI for interactive API testing.

Access Swagger UI at: `/swagger-ui.html`
